### PR TITLE
Fix bug that prevents distributing multiple required files

### DIFF
--- a/distributed/driver/scheduler/scheduler_execute_task_group.go
+++ b/distributed/driver/scheduler/scheduler_execute_task_group.go
@@ -87,8 +87,10 @@ func (s *Scheduler) ExecuteTaskGroup(ctx context.Context,
 			err := withClient(allocation.Location.URL(), func(client pb.GleamAgentClient) error {
 				for _, relatedFile := range relatedFiles {
 					err := sendRelatedFile(ctx, client, fc.HashCode, relatedFile)
-					taskGroup.MarkStop(err)
-					return err
+					if err != nil {
+						taskGroup.MarkStop(err)
+						return err
+					}
 				}
 				return nil
 			})


### PR DESCRIPTION
Currently it is not possible to upload more than one required file to the agent hosts. This aims to fix that. 