### PR TITLE
fix issue #80

### DIFF
--- a/gio/runner_grpc_client_to_executor.go
+++ b/gio/runner_grpc_client_to_executor.go
@@ -74,7 +74,7 @@ func withClient(server string, fn func(client pb.GleamExecutorClient) error) err
 	}
 
 	// add block option to avoid premature connection
-	grpcConection, err := grpc.Dial(server, grpc.WithInsecure(), grpc, grpc.WithBlock())
+	grpcConection, err := grpc.Dial(server, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		return fmt.Errorf("executor dial agent: %v", err)
 	}

--- a/gio/runner_grpc_client_to_executor.go
+++ b/gio/runner_grpc_client_to_executor.go
@@ -75,11 +75,14 @@ func withClient(server string, fn func(client pb.GleamExecutorClient) error) err
 	if err != nil {
 		return fmt.Errorf("executor dial agent: %v", err)
 	}
+	/**  Could be closed prematurely before fn finish its use of the connection
 	defer func() {
 		time.Sleep(50 * time.Millisecond)
 		grpcConection.Close()
 	}()
+	*/
 	client := pb.NewGleamExecutorClient(grpcConection)
-
-	return fn(client)
+	err = fn(client)
+	defer grpcConection.Close()  // fn has finished its use of the client, connection could be closed safely
+	return err
 }


### PR DESCRIPTION
It appears that grpc connection somehow stays in IDLE / TRANSIENT_FAILURE state when the mapper/reducer runner tries to heartbeat/report to the executor. Maybe this connection issue is dependent on the OS environment. However, adding `grpc.WithBlock()` to the dial options and `grpc.FailFast(false)` to the call options solved the issue I confronted. 

see [gRPC Wait for Ready Semantics](https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)