### PR TITLE
send the first heartbeat immediately after the agent starts

### DIFF
--- a/distributed/agent/agent_grpc_client_to_master.go
+++ b/distributed/agent/agent_grpc_client_to_master.go
@@ -36,6 +36,7 @@ func (as *AgentServer) doHeartbeat(sleepInterval time.Duration) error {
 		log.Printf("SendHeartbeat error: %v", err)
 		return err
 	}
+	as.sendOneHeartbeat(stream)
 
 	log.Printf("Heartbeat to %s", as.Master)
 


### PR DESCRIPTION
Without this I have to wait for 10 seconds after the agent started