### PR TITLE
fix driver path in distributed mode

### DIFF
--- a/distributed/agent/agent_server_execute.go
+++ b/distributed/agent/agent_server_execute.go
@@ -29,6 +29,8 @@ func (as *AgentServer) executeCommand(
 		ctx,
 		executableFullFilename,
 		"execute",
+		"--dir",
+		dir,
 		"--note",
 		startRequest.GetInstructionSet().GetName(),
 	)

--- a/distributed/gleam/gleam.go
+++ b/distributed/gleam/gleam.go
@@ -33,6 +33,7 @@ var (
 
 	executor     = app.Command("execute", "Execute an instruction set")
 	executorNote = executor.Flag("note", "description").String()
+	executorDir  = executor.Flag("dir", "working directory of the executor").String()
 
 	agent       = app.Command("agent", "Agent that can accept read, write requests, manage executors")
 	agentOption = &a.AgentServerOption{
@@ -107,6 +108,7 @@ func main() {
 
 		if err := exe.NewExecutor(&exe.ExecutorOption{
 			AgentAddress: instructionSet.AgentAddress,
+			Dir:          *executorDir,
 		}, &instructionSet).ExecuteInstructionSet(); err != nil {
 			log.Fatalf("Failed task %s: %v", *executorNote, err)
 		}

--- a/flow/dataset_map.go
+++ b/flow/dataset_map.go
@@ -2,7 +2,7 @@ package flow
 
 import (
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/chrislusf/gleam/gio"
 	"github.com/chrislusf/gleam/instruction"
@@ -20,12 +20,12 @@ func (d *Dataset) Map(name string, mapperId gio.MapperId) *Dataset {
 	ex, _ := os.Executable()
 
 	var args []string
-	args = append(args, ex)
-	// args = append(args, os.Args[1:]...) // empty string in an arg can fail the execution
-	args = append(args, "-gleam.mapper="+string(mapperId))
-	commandLine := strings.Join(args, " ")
-	// println("args:", commandLine)
-	step.Command = script.NewShellScript().Pipe(commandLine).GetCommand()
+	args = append(args, os.Args[1:]...)
+	args = append(args, "-gleam.mapper", string(mapperId))
+	step.Command = &script.Command{
+		Path: filepath.Base(ex),
+		Args: args,
+	}
 	return ret
 }
 

--- a/flow/dataset_reduce.go
+++ b/flow/dataset_reduce.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -63,14 +64,13 @@ func (d *Dataset) LocalReduceBy(name string, reducerId gio.ReducerId, sortOption
 	ex, _ := os.Executable()
 
 	var args []string
-	args = append(args, ex)
 	args = append(args, os.Args[1:]...)
-	args = append(args, "-gleam.reducer="+string(reducerId))
-	args = append(args, "-gleam.keyFields="+keyFields)
+	args = append(args, "-gleam.reducer", string(reducerId))
+	args = append(args, "-gleam.keyFields", keyFields)
 
-	commandLine := strings.Join(args, " ")
-
-	step.Command = script.NewShellScript().Pipe(commandLine).GetCommand()
-
+	step.Command = &script.Command{
+		Path: filepath.Base(ex),
+		Args: args,
+	}
 	return ret
 }


### PR DESCRIPTION
Without this patch, if the driver and the executor are running on different servers, the driver binary is uploaded to the job's temporary directory. But when the executor start the mapper or reducer process, it used the absolute path without the temporary directory prefix. 