### PR TITLE
reap the mapper and reducer processes when job is interrupted

### DIFF
--- a/distributed/netchan/channels.go
+++ b/distributed/netchan/channels.go
@@ -18,7 +18,8 @@ import (
 
 func DialReadChannel(ctx context.Context, wg *sync.WaitGroup, readerName string, address string, channelName string, onDisk bool, outChan io.WriteCloser) error {
 
-	conn, err := net.Dial("tcp", address)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		wg.Done()
 		return fmt.Errorf("Fail to dial read %s: %v", address, err)
@@ -52,7 +53,8 @@ func DialReadChannel(ctx context.Context, wg *sync.WaitGroup, readerName string,
 
 func DialWriteChannel(ctx context.Context, wg *sync.WaitGroup, writerName string, address string, channelName string, onDisk bool, inChan io.Reader, readerCount int) error {
 
-	conn, err := net.Dial("tcp", address)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		wg.Done()
 		return fmt.Errorf("Fail to dial write %s: %v", address, err)


### PR DESCRIPTION
Before this change:
When a job starts, the agent starts the executor process, which then starts the mapper and reducer processes.
If the job is interrupted, the executor process is terminated by `SIGKILL` and its children will be left behind.

This patch changed the `exec.CommandContext` to `exec.Command` and send `SIGTERM` to the executor process when the job is canceled. Thus the executor process is able to reap its children.