### PR TITLE
Added arguments to mapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ func main() {
 
 }
 
-func tokenize(row []interface{}) error {
+func tokenize(row []interface{}, _ ...interface{}) error {
 	line := gio.ToString(row[0])
 	for _, s := range strings.FieldsFunc(line, func(r rune) bool {
 		return !('A' <= r && r <= 'Z' || 'a' <= r && r <= 'z' || '0' <= r && r <= '9')
@@ -135,7 +135,7 @@ func tokenize(row []interface{}) error {
 	return nil
 }
 
-func appendOne(row []interface{}) error {
+func appendOne(row []interface{}, _ ...interface{}) error {
 	row = append(row, 1)
 	gio.Emit(row...)
 	return nil

--- a/examples/orc/orc_reading.go
+++ b/examples/orc/orc_reading.go
@@ -39,7 +39,7 @@ func main() {
 
 }
 
-func absolute(row []interface{}) error {
+func absolute(row []interface{}, _ ...interface{}) error {
 	a, b := gio.ToString(row[0]), gio.ToInt64(row[1])
 	if b < 0 {
 		b = -b

--- a/examples/pi_estimation/pi_estimation.go
+++ b/examples/pi_estimation/pi_estimation.go
@@ -150,7 +150,7 @@ func testLocalFlow() {
 	fmt.Println()
 }
 
-func monteCarloMapper(row []interface{}) error {
+func monteCarloMapper(row []interface{}, _ ...interface{}) error {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	var count int

--- a/examples/sort_benchmark/sort_benchmark.go
+++ b/examples/sort_benchmark/sort_benchmark.go
@@ -86,7 +86,7 @@ func gleamSortDistributed(fileName string, size int64, partition int, isDistribu
 	}
 }
 
-func splitLine(row []interface{}) error {
+func splitLine(row []interface{}, _ ...interface{}) error {
 	line := row[0].(string)
 	gio.Emit(line[0:10], line[12:])
 	return nil

--- a/examples/tfidf/tfidf.go
+++ b/examples/tfidf/tfidf.go
@@ -71,7 +71,7 @@ func main() {
 
 }
 
-func readContent(x []interface{}) error {
+func readContent(x []interface{}, _ ...interface{}) error {
 
 	filepath := gio.ToString(x[0])
 
@@ -93,7 +93,7 @@ func readContent(x []interface{}) error {
 	return nil
 }
 
-func tfidf(x []interface{}) error {
+func tfidf(x []interface{}, _ ...interface{}) error {
 	fmt.Fprintf(os.Stderr, "tfidf input: %v\n", x)
 	word := gio.ToString(x[0])
 	df := uint16(gio.ToInt64(x[1]))

--- a/flow/dataset_map_test.go
+++ b/flow/dataset_map_test.go
@@ -1,0 +1,65 @@
+package flow_test
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/chrislusf/gleam/flow"
+	"github.com/chrislusf/gleam/gio"
+	"github.com/chrislusf/gleam/pb"
+	"github.com/chrislusf/gleam/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func toRows(data [][]interface{}) func(io.Writer, *pb.InstructionStat) error {
+	return func(outWriter io.Writer, stat *pb.InstructionStat) error {
+		for _, values := range data {
+			if err := util.NewRow(util.Now(), values...).WriteTo(outWriter); err != nil {
+				return err
+			}
+			stat.OutputCounter++
+		}
+		return nil
+	}
+}
+
+func addX(row []interface{}, args ...interface{}) error {
+	row = []interface{}{row[0], args[0].(float64)}
+	gio.Emit(row...)
+	return nil
+}
+
+var addXId = gio.RegisterMapper(addX)
+
+func TestMapper(t *testing.T) {
+	gio.Init()
+
+	// function to be used in Output. Stores the result in `result`
+	var result []interface{}
+	collect := func(r io.Reader) error {
+		return util.ProcessMessage(r, func(encodedBytes []byte) error {
+			row, _ := util.DecodeRow(encodedBytes)
+			result = append(result, row)
+			return nil
+		})
+	}
+
+	data := make([][]interface{}, 2)
+	for i, _ := range data {
+		data[i] = make([]interface{}, 2)
+		data[i] = []interface{}{i, i}
+	}
+
+	var arg1 int64 = 10
+
+	flow.New("").Source("a", toRows(data)).Map("add10", addXId, arg1).Output(collect).Run()
+
+	fmt.Println(result)
+
+	assert.Equal(t, []interface{}{int64(0)}, result[0].(*util.Row).K)
+	assert.Equal(t, []interface{}{arg1}, result[0].(*util.Row).V)
+
+	assert.Equal(t, []interface{}{int64(1)}, result[1].(*util.Row).K)
+	assert.Equal(t, []interface{}{arg1}, result[1].(*util.Row).V)
+}

--- a/gio/map_reduce.go
+++ b/gio/map_reduce.go
@@ -12,14 +12,16 @@ import (
 )
 
 type MapperId string
+type MapperArgs []byte
 type ReducerId string
-type Mapper func([]interface{}) error
+type Mapper func([]interface{}, ...interface{}) error
 type Reducer func(x, y interface{}) (interface{}, error)
 
 type gleamTaskOption struct {
 	Mapper          string
 	Reducer         string
 	KeyFields       string
+	MapperArgs      string // json-marshalled
 	ExecutorAddress string
 	HashCode        uint
 	StepId          int
@@ -40,6 +42,7 @@ var (
 
 func init() {
 	flag.StringVar(&taskOption.Mapper, "gleam.mapper", "", "the generated mapper name")
+	flag.StringVar(&taskOption.MapperArgs, "gleam.mapperArgs", "", "arguments for the mapper in JSON")
 	flag.StringVar(&taskOption.Reducer, "gleam.reducer", "", "the generated reducer name")
 	flag.StringVar(&taskOption.KeyFields, "gleam.keyFields", "", "the 1-based key fields")
 	flag.StringVar(&taskOption.ExecutorAddress, "gleam.executor", "", "executor address")

--- a/gio/mapper.go
+++ b/gio/mapper.go
@@ -9,13 +9,13 @@ import (
 	"github.com/chrislusf/gleam/util"
 )
 
-func (runner *gleamRunner) processMapper(ctx context.Context, f Mapper) (err error) {
+func (runner *gleamRunner) processMapper(ctx context.Context, f Mapper, arguments []interface{}) (err error) {
 	return runner.report(ctx, func() error {
-		return runner.doProcessMapper(ctx, f)
+		return runner.doProcessMapper(ctx, f, arguments)
 	})
 }
 
-func (runner *gleamRunner) doProcessMapper(ctx context.Context, f Mapper) error {
+func (runner *gleamRunner) doProcessMapper(ctx context.Context, f Mapper, arguments []interface{}) error {
 	for {
 		row, err := util.ReadRow(os.Stdin)
 		if err != nil {
@@ -29,7 +29,7 @@ func (runner *gleamRunner) doProcessMapper(ctx context.Context, f Mapper) error 
 		var data []interface{}
 		data = append(data, row.K...)
 		data = append(data, row.V...)
-		err = f(data)
+		err = f(data, arguments...)
 		if err != nil {
 			return fmt.Errorf("processing error: %v", err)
 		}

--- a/gio/mapper/simple_mapper.go
+++ b/gio/mapper/simple_mapper.go
@@ -11,7 +11,7 @@ var (
 	AppendOne = gio.RegisterMapper(addOne)
 )
 
-func tokenize(row []interface{}) error {
+func tokenize(row []interface{}, _ ...interface{}) error {
 
 	line := gio.ToString(row[0])
 
@@ -24,7 +24,7 @@ func tokenize(row []interface{}) error {
 	return nil
 }
 
-func addOne(row []interface{}) error {
+func addOne(row []interface{}, _ ...interface{}) error {
 	row = append(row, 1)
 
 	gio.Emit(row...)

--- a/gio/runner.go
+++ b/gio/runner.go
@@ -2,6 +2,7 @@ package gio
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -57,7 +58,13 @@ func (runner *gleamRunner) runMapperReducer() {
 
 	if runner.Option.Mapper != "" {
 		if fn, ok := mappers[MapperId(runner.Option.Mapper)]; ok {
-			if err := runner.processMapper(ctx, fn.Mapper); err != nil {
+			var args []interface{}
+			if len(runner.Option.MapperArgs) > 0 {
+				if err := json.Unmarshal(MapperArgs(runner.Option.MapperArgs), &args); err != nil {
+					log.Fatalf("Failed to de-serialize mapper %v arguments: %v", os.Args, err)
+				}
+			}
+			if err := runner.processMapper(ctx, fn.Mapper, args); err != nil {
 				log.Fatalf("Failed to execute mapper %v: %v", os.Args, err)
 			}
 			return

--- a/plugins/cassandra/cassandra_shard_info.go
+++ b/plugins/cassandra/cassandra_shard_info.go
@@ -34,7 +34,7 @@ func init() {
 	gob.Register(CassandraShardInfo{})
 }
 
-func readShard(row []interface{}) error {
+func readShard(row []interface{}, _ ...interface{}) error {
 	encodedShardInfo := row[0].([]byte)
 	return decodeShardInfo(encodedShardInfo).ReadSplit()
 }

--- a/plugins/file/file_shard_info.go
+++ b/plugins/file/file_shard_info.go
@@ -28,7 +28,7 @@ func init() {
 	gob.Register(FileShardInfo{})
 }
 
-func readShard(row []interface{}) error {
+func readShard(row []interface{}, _ ...interface{}) error {
 	encodedShardInfo := row[0].([]byte)
 	return decodeShardInfo(encodedShardInfo).ReadSplit()
 }

--- a/plugins/kafka/kafka_partition_info.go
+++ b/plugins/kafka/kafka_partition_info.go
@@ -26,7 +26,7 @@ func init() {
 	gob.Register(KafkaPartitionInfo{})
 }
 
-func readShard(row []interface{}) error {
+func readShard(row []interface{}, _ ...interface{}) error {
 	encodedShardInfo := row[0].([]byte)
 	return decodeShardInfo(encodedShardInfo).ReadSplit()
 }


### PR DESCRIPTION
This is a backward-incompatible change that modifies the signature of all mappers from `(row)` to `(row, ...args)` and `Map(name, f)` to `Map(name, f, ...args)`, where `args` are passed by the driver to the executors.

This allows for more complex map operations where the maps depend on intermediary operations / arguments known to the driver.

I used `json` for serializing/deserializing the arguments, as per comments in #185. The tests are currently failing because marshaling/unmarshaling changes the argument's types (`int64` -> `float64`). In general, I believe that we want to keep the types as part of the serialization / de-serialization, which hints that the json may not be sufficient for our needs. However. I do not have a strong opinion on this: @chrislusf , what do you think?

I decided to use `"github.com/stretchr/testify/assert"` for the testing, but I have no strong opinions about it. My experience is that it is easy to tell when something is not equal.
