### PR TITLE
change all references of whitespace to empty space

### DIFF
--- a/plugins/file/csv/generic_csv_reader.go
+++ b/plugins/file/csv/generic_csv_reader.go
@@ -10,11 +10,11 @@
 //
 //	field1,field2,field3
 //
-// White space is considered part of a field.
+// Empty space is considered part of a field.
 //
 // Carriage returns before newline characters are silently removed.
 //
-// Blank lines are ignored.  A line with only whitespace characters (excluding
+// Blank lines are ignored.  A line with only empty space characters (excluding
 // the ending newline character) is not considered a blank line.
 //
 // Fields which start and stop with the quote character " are called
@@ -103,7 +103,7 @@ const (
 // If LazyQuotes is true, a quote may appear in an unquoted field and a
 // non-doubled quote may appear in a quoted field.
 //
-// If TrimLeadingSpace is true, leading white space in a field is ignored.
+// If TrimLeadingSpace is true, leading empty space in a field is ignored.
 type Reader struct {
 	Comma            rune // field delimiter (set to ',' by NewReader)
 	Comment          rune // comment character for start of line

--- a/sql/parser/lexer.go
+++ b/sql/parser/lexer.go
@@ -135,7 +135,7 @@ func NewScanner(s string) *Scanner {
 	return &Scanner{r: reader{s: s}}
 }
 
-func (s *Scanner) skipWhitespace() rune {
+func (s *Scanner) skipEmptySpace() rune {
 	return s.r.incAsLongAs(unicode.IsSpace)
 }
 
@@ -158,7 +158,7 @@ func (s *Scanner) scan() (tok int, pos Pos, lit string) {
 
 	ch0 := s.r.peek()
 	if unicode.IsSpace(ch0) {
-		ch0 = s.skipWhitespace()
+		ch0 = s.skipEmptySpace()
 	}
 	pos = s.r.pos()
 	if s.r.eof() {
@@ -370,11 +370,11 @@ func startString(s *Scanner) (tok int, pos Pos, lit string) {
 
 	// Quoted strings placed next to each other are concatenated to a single string.
 	// See http://dev.mysql.com/doc/refman/5.7/en/string-literals.html
-	ch := s.skipWhitespace()
+	ch := s.skipEmptySpace()
 	for ch == '\'' || ch == '"' {
 		_, _, lit1 := s.scanString()
 		lit = lit + lit1
-		ch = s.skipWhitespace()
+		ch = s.skipEmptySpace()
 	}
 	return
 }

--- a/sql/util/charset/encoding_table.go
+++ b/sql/util/charset/encoding_table.go
@@ -28,7 +28,7 @@ import (
 // Lookup returns the encoding with the specified label, and its canonical
 // name. It returns nil and the empty string if label is not one of the
 // standard encodings for HTML. Matching is case-insensitive and ignores
-// leading and trailing whitespace.
+// leading and trailing empty space.
 func Lookup(label string) (e encoding.Encoding, name string) {
 	label = strings.ToLower(strings.Trim(label, "\t\n\r\f "))
 	enc := encodings[label]

--- a/sql/util/types/time.go
+++ b/sql/util/types/time.go
@@ -1848,8 +1848,8 @@ func mysqlTimeFix(t *mysqlTime, ctx map[string]int) error {
 // strToDate converts date string according to format, returns true on success,
 // the value will be stored in argument t or ctx.
 func strToDate(t *mysqlTime, date string, format string, ctx map[string]int) bool {
-	date = skipWhiteSpace(date)
-	format = skipWhiteSpace(format)
+	date = skipEmptySpace(date)
+	format = skipEmptySpace(format)
 
 	token, formatRemain, succ := getFormatToken(format)
 	if !succ {
@@ -1892,7 +1892,7 @@ func getFormatToken(format string) (token string, remain string, succ bool) {
 	return format[:1], format[1:], true
 }
 
-func skipWhiteSpace(input string) string {
+func skipEmptySpace(input string) string {
 	for i, c := range input {
 		if !unicode.IsSpace(c) {
 			return input[i:]
@@ -2036,7 +2036,7 @@ func time12Hour(t *mysqlTime, input string, ctx map[string]int) (string, bool) {
 		return input, false
 	}
 
-	remain := skipWhiteSpace(input[8:])
+	remain := skipEmptySpace(input[8:])
 	switch {
 	case strings.HasPrefix(remain, "AM"):
 		t.hour = uint8(hour)


### PR DESCRIPTION
In an attempt to be more inclusive, I believe all instances of the word "whitespace" should be replaced by the term "empty space". The word "white" has so often existed under racist undertones, being used in place of neutrality or default in different programming spaces. Although a small change, the impact can lead to larger implications over time.

Inspiration: discussions of phasing out whitelist/blacklist
- https://www.clockwork.com/news/creating-inclusive-naming-conventions-in-technology/