### PR TITLE
Fix key/value order after flow.Sort

### DIFF
--- a/instruction/merge_sorted_to.go
+++ b/instruction/merge_sorted_to.go
@@ -49,17 +49,35 @@ func (b *MergeSortedTo) GetMemoryCostInMB(partitionSize int64) int64 {
 	return 20
 }
 
+type rowWithOriginalData struct {
+	row       *util.Row
+	originalK []interface{}
+	originalV []interface{}
+}
+
+func newRowWithOriginalData(row *util.Row) *rowWithOriginalData {
+	return &rowWithOriginalData{row: row, originalK: row.K, originalV: row.V}
+}
+
+func newMinQueueOfRowsWithOriginalData(orderBys []OrderBy) *util.PriorityQueue {
+	return util.NewPriorityQueue(func(a, b interface{}) bool {
+		x, y := a.(*rowWithOriginalData), b.(*rowWithOriginalData)
+		return lessThan(orderBys, x.row, y.row)
+	})
+}
+
 func DoMergeSortedTo(readers []io.Reader, writer io.Writer, orderBys []OrderBy, stats *pb.InstructionStat) error {
 	indexes := getIndexesFromOrderBys(orderBys)
 
-	pq := newMinQueueOfPairs(orderBys)
+	pq := newMinQueueOfRowsWithOriginalData(orderBys)
 
 	// enqueue one item to the pq from each channel
 	for shardId, reader := range readers {
 		if row, err := util.ReadRow(reader); err == nil {
+			rowWithOriginalData := newRowWithOriginalData(row)
 			row.UseKeys(indexes)
 			stats.InputCounter++
-			pq.Enqueue(row, shardId)
+			pq.Enqueue(rowWithOriginalData, shardId)
 		} else {
 			if err != io.EOF {
 				log.Printf("DoMergeSortedTo failed start :%v", err)
@@ -69,15 +87,19 @@ func DoMergeSortedTo(readers []io.Reader, writer io.Writer, orderBys []OrderBy, 
 	}
 	for pq.Len() > 0 {
 		t, shardId := pq.Dequeue()
-		if err := t.(*util.Row).WriteTo(writer); err != nil {
+		rowWithOriginalData := t.(*rowWithOriginalData)
+		rowWithOriginalData.row.K = rowWithOriginalData.originalK
+		rowWithOriginalData.row.V = rowWithOriginalData.originalV
+		if err := rowWithOriginalData.row.WriteTo(writer); err != nil {
 			return err
 		}
 		stats.OutputCounter++
 
 		if row, err := util.ReadRow(readers[shardId]); err == nil {
+			rowWithOriginalData := newRowWithOriginalData(row)
 			row.UseKeys(indexes)
 			stats.InputCounter++
-			pq.Enqueue(row, shardId)
+			pq.Enqueue(rowWithOriginalData, shardId)
 		} else {
 			if err != io.EOF {
 				log.Printf("DoMergeSortedTo failed to ReadRow :%v", err)


### PR DESCRIPTION
Fixes #151.

Using the same program in the comments of the issue gives the following output for both LocalSort and Sort:

```
3	4
2	3
1	2
```